### PR TITLE
Implement starting a ride endpoint

### DIFF
--- a/BACKEND/src/main/java/com/project/backend/controllers/RideController.java
+++ b/BACKEND/src/main/java/com/project/backend/controllers/RideController.java
@@ -15,6 +15,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
@@ -82,9 +83,14 @@ public class RideController {
     }
 
     @PatchMapping("/{id}/start")
+    @PreAuthorize("hasRole('DRIVER')")
     public ResponseEntity<?> startRide(@PathVariable String id) {
-        return ResponseEntity.status(501)
-                .body(Map.of("error", "Not implemented"));
+        var user = authUtils.getCurrentUser();
+        if (user == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                    .body(Map.of("error", "Unauthorized"));
+        }
+        return ResponseEntity.ok(rideService.startARide(id,user.getId()));
     }
     
     @PatchMapping("/{id}/finish")

--- a/BACKEND/src/main/java/com/project/backend/models/Driver.java
+++ b/BACKEND/src/main/java/com/project/backend/models/Driver.java
@@ -2,9 +2,7 @@ package com.project.backend.models;
 
 import com.project.backend.models.enums.DriverStatus;
 import com.project.backend.models.enums.UserRole;
-import jakarta.persistence.DiscriminatorValue;
-import jakarta.persistence.Entity;
-import jakarta.persistence.OneToMany;
+import jakarta.persistence.*;
 import lombok.*;
 
 import java.util.List;
@@ -17,6 +15,7 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 public class Driver extends AppUser {
+    @Enumerated(EnumType.STRING)
     private DriverStatus driverStatus;
     @OneToMany
     private List<DriverActivity> driverActivities;

--- a/BACKEND/src/main/java/com/project/backend/models/enums/DriverStatus.java
+++ b/BACKEND/src/main/java/com/project/backend/models/enums/DriverStatus.java
@@ -1,5 +1,6 @@
 package com.project.backend.models.enums;
 
 public enum DriverStatus {
-    WAITING_ACTIVATION
+    WAITING_ACTIVATION,
+    BUSY
 }

--- a/BACKEND/src/main/java/com/project/backend/service/IRideService.java
+++ b/BACKEND/src/main/java/com/project/backend/service/IRideService.java
@@ -3,8 +3,12 @@ package com.project.backend.service;
 import com.project.backend.DTO.Ride.RideBookingParametersDTO;
 import com.project.backend.DTO.Ride.RideResponseDTO;
 
+import java.util.Map;
+
 public interface IRideService {
     RideResponseDTO getRideById(Long id);
 
     Object createRide(Long id, RideBookingParametersDTO body);
+
+    Map<String, Object> startARide(String id, Long id1);
 }


### PR DESCRIPTION
Closes #76 

This pull request introduces the implementation for starting a ride, including new authorization checks, service logic, and model updates. The main changes are the addition of a secure endpoint for drivers to start rides, updates to the `Driver` and `DriverStatus` models to support ride status transitions, and the corresponding service logic that enforces business rules and updates relevant entities.

**Authorization & Controller Enhancements**
* Added `@PreAuthorize("hasRole('DRIVER')")` to the `startRide` endpoint in `RideController`, ensuring only users with the DRIVER role can start a ride. The endpoint now checks authentication and delegates to the service for ride start logic. [[1]](diffhunk://#diff-44a164aca01d3fc87ffcae6bd70d20ae0bf80de1dba7418c2043caa8f3c30fc0R18) [[2]](diffhunk://#diff-44a164aca01d3fc87ffcae6bd70d20ae0bf80de1dba7418c2043caa8f3c30fc0R86-R93)

**Service Layer Implementation**
* Implemented the `startARide` method in `RideService`, which checks driver assignment, ride status, updates ride and driver status, and returns a response. The method is transactional and enforces business rules for starting a ride.
* Declared the `startARide` method in the `IRideService` interface.

**Model Updates**
* Added the `BUSY` status to the `DriverStatus` enum to represent a driver engaged in a ride.
* Updated the `Driver` model to annotate `driverStatus` with `@Enumerated(EnumType.STRING)` for proper persistence.
* Minor import optimizations in `Driver.java` to consolidate JPA annotations.

**Exception Handling**
* Imported new exceptions (`ForbiddenException`) in `RideService` to handle unauthorized ride starts.