### PR TITLE
Refactor ride service to use events for sending emails

### DIFF
--- a/BACKEND/src/main/java/com/project/backend/events/RideCreatedEvent.java
+++ b/BACKEND/src/main/java/com/project/backend/events/RideCreatedEvent.java
@@ -1,0 +1,11 @@
+package com.project.backend.events;
+
+import com.project.backend.models.Ride;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class RideCreatedEvent {
+    private Ride ride;
+}

--- a/BACKEND/src/main/java/com/project/backend/listeners/RideListener.java
+++ b/BACKEND/src/main/java/com/project/backend/listeners/RideListener.java
@@ -1,0 +1,43 @@
+package com.project.backend.listeners;
+
+import com.project.backend.events.RideCreatedEvent;
+import com.project.backend.service.EmailBodyGeneratorService;
+import com.project.backend.service.EmailService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class RideListener {
+    private final EmailService emailService;
+    private final EmailBodyGeneratorService emailBodyGeneratorService;
+    @Value("${frontend.url}")
+    private String frontendUrl;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void sendEmails(RideCreatedEvent event) {
+        var ride = event.getRide();
+        var ownerName = ride.getRideOwner().getFirstName() + " " + ride.getRideOwner().getLastName();
+        var url = frontendUrl + "/ride/" + ride.getId() + "/track?accessToken=";
+        for (var passenger : ride.getPassengers()) {
+            try {
+                emailService.sendEmail(
+                        passenger.getEmail() != null ?
+                                passenger.getEmail() :
+                                passenger.getUser().getEmail(),
+                        "New ride",
+                        emailBodyGeneratorService.generatePassengerAddedEmail(
+                                ownerName,
+                                url + passenger.getAccessToken()
+                        )
+                );
+            }
+            catch (Exception e) {
+                //throw new RuntimeException(e);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #95 
This pull request introduces an event-driven approach for sending emails to passengers when a new ride is created. Instead of handling email notifications directly in the `RideService`, the logic is now decoupled using a `RideCreatedEvent` and a corresponding listener. This improves code modularity and maintainability.

**Event-driven email notification refactor:**

* Added a new `RideCreatedEvent` class to encapsulate ride creation events.
* Removed direct email sending logic from `RideService` and replaced it with publishing a `RideCreatedEvent` using `ApplicationEventPublisher`. [[1]](diffhunk://#diff-365126cbad15ed0a94dc51b805ea8252f87840bd0a57df9711d739a0d38570b6L111-R108) [[2]](diffhunk://#diff-365126cbad15ed0a94dc51b805ea8252f87840bd0a57df9711d739a0d38570b6L35-L41) [[3]](diffhunk://#diff-365126cbad15ed0a94dc51b805ea8252f87840bd0a57df9711d739a0d38570b6L18-R23) [[4]](diffhunk://#diff-365126cbad15ed0a94dc51b805ea8252f87840bd0a57df9711d739a0d38570b6R10)
* Introduced a new `RideListener` component that listens for `RideCreatedEvent` and handles sending emails to passengers after the transaction commits.