### PR TITLE
Implement start a ride button with back integration

### DIFF
--- a/WEB/src/app/features/driver/rides/components/start-ride-button/start-ride-button.component.css
+++ b/WEB/src/app/features/driver/rides/components/start-ride-button/start-ride-button.component.css
@@ -1,0 +1,5 @@
+.start-ride-btn {
+	background-color: #37ff00;
+	color: black;
+	border: none;
+}

--- a/WEB/src/app/features/driver/rides/components/start-ride-button/start-ride-button.component.html
+++ b/WEB/src/app/features/driver/rides/components/start-ride-button/start-ride-button.component.html
@@ -1,0 +1,1 @@
+<button appButton (click)="startRide()" class="start-ride-btn">Start Ride</button>

--- a/WEB/src/app/features/driver/rides/components/start-ride-button/start-ride-button.component.spec.ts
+++ b/WEB/src/app/features/driver/rides/components/start-ride-button/start-ride-button.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { StartRideButtonComponent } from './start-ride-button.component';
+
+describe('StartRideButtonComponent', () => {
+  let component: StartRideButtonComponent;
+  let fixture: ComponentFixture<StartRideButtonComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [StartRideButtonComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(StartRideButtonComponent);
+    component = fixture.componentInstance;
+    await fixture.whenStable();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/WEB/src/app/features/driver/rides/components/start-ride-button/start-ride-button.component.ts
+++ b/WEB/src/app/features/driver/rides/components/start-ride-button/start-ride-button.component.ts
@@ -1,0 +1,40 @@
+import { Component, inject, input, output } from '@angular/core';
+import { ButtonDirective } from '@shared/directives/button/button.directive';
+import { DriverRideService } from '@features/driver/rides/services/driver-ride.service';
+import Swal from 'sweetalert2';
+
+@Component({
+	selector: 'app-start-ride-button',
+	imports: [ButtonDirective],
+	providers: [DriverRideService],
+	templateUrl: './start-ride-button.component.html',
+	styleUrl: './start-ride-button.component.css',
+})
+export class StartRideButtonComponent {
+	private driverRideService = inject(DriverRideService);
+
+	rideId = input.required<number>();
+
+	rideStarted = output<void>()
+
+	startRide(): void {
+		this.driverRideService.startRide(this.rideId()).subscribe({
+			next: (response) => {
+				this.rideStarted.emit();
+				Swal.fire({
+					title: 'Success',
+					text: response.message,
+					icon: 'success',
+				}).then();
+			},
+			error: (error) => {
+				console.error('Error starting ride:', error);
+				Swal.fire({
+					title: 'Error',
+					text: error?.error?.message ?? 'Error starting ride',
+					icon: 'error',
+				}).then();
+			},
+		});
+	}
+}

--- a/WEB/src/app/features/driver/rides/models/api-responses.model.ts
+++ b/WEB/src/app/features/driver/rides/models/api-responses.model.ts
@@ -1,0 +1,7 @@
+
+export interface StartRideResponse {
+	"ok": boolean,
+	"driverStatus": string,
+	"rideStatus": string,
+	"message": string
+}

--- a/WEB/src/app/features/driver/rides/pages/ride-details-page/ride-details-page.component.html
+++ b/WEB/src/app/features/driver/rides/pages/ride-details-page/ride-details-page.component.html
@@ -1,4 +1,5 @@
 <p>ride-details-page works!</p>
 <app-cancel-ride-button [rideId]="rideId()" />
 <app-end-ride-button [rideId]="rideId()" />
+<app-start-ride-button [rideId]="rideId()" (rideStarted)="refresh()" />
 <app-panic-button />

--- a/WEB/src/app/features/driver/rides/pages/ride-details-page/ride-details-page.component.ts
+++ b/WEB/src/app/features/driver/rides/pages/ride-details-page/ride-details-page.component.ts
@@ -3,10 +3,18 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { CancelRideButtonComponent } from '@features/driver/rides/components/cancel-ride-button/cancel-ride-button.component';
 import { EndRideButtonComponent } from '@features/driver/rides/components/end-ride-button/end-ride-button.component';
 import { PanicButtonComponent } from '@shared/components/panic-button/panic-button.component';
+import {
+	StartRideButtonComponent
+} from '@features/driver/rides/components/start-ride-button/start-ride-button.component';
 
 @Component({
 	selector: 'app-rides-details-page',
-	imports: [CancelRideButtonComponent, EndRideButtonComponent, PanicButtonComponent],
+	imports: [
+		CancelRideButtonComponent,
+		EndRideButtonComponent,
+		PanicButtonComponent,
+		StartRideButtonComponent,
+	],
 	templateUrl: './ride-details-page.component.html',
 	styleUrl: './ride-details-page.component.css',
 })
@@ -24,5 +32,9 @@ export class RideDetailsPageComponent implements OnInit {
 				.then();
 		}
 		this.rideId.set(parseInt(id!));
+	}
+
+	protected refresh() {
+		alert("Refresh ride details logic goes here")
 	}
 }

--- a/WEB/src/app/features/driver/rides/services/driver-ride.service.ts
+++ b/WEB/src/app/features/driver/rides/services/driver-ride.service.ts
@@ -3,6 +3,7 @@ import { HttpClient } from '@angular/common/http';
 import { environment } from '@environments/environment';
 import { CostTime } from '@shared/models/cost-time.model';
 import { Observable } from 'rxjs';
+import { StartRideResponse } from '@features/driver/rides/models/api-responses.model';
 
 @Injectable()
 export class DriverRideService {
@@ -21,5 +22,12 @@ export class DriverRideService {
 
 	endRide(rideId: number): Observable<CostTime> {
 		return this.http.patch<CostTime>(`/api/${environment.apiVersion}/rides/${rideId}/end`, {});
+	}
+
+	startRide(rideId: number): Observable<StartRideResponse> {
+		return this.http.patch<StartRideResponse>(
+			`/api/${environment.apiVersion}/rides/${rideId}/start`,
+			{},
+		);
 	}
 }


### PR DESCRIPTION
Closes #80 
This pull request introduces a new "Start Ride" button component to the driver ride details page, allowing drivers to initiate a ride. It includes the UI, business logic, API integration, and testing for the new feature. Additionally, the ride details page is updated to incorporate this new component and handle ride start events.

**New "Start Ride" feature:**

- Added `StartRideButtonComponent` with UI, logic, and SweetAlert feedback for starting a ride, including input/output bindings for ride ID and event emission (`start-ride-button.component.ts`, `start-ride-button.component.html`, `start-ride-button.component.css`). [[1]](diffhunk://#diff-2397654ac9a6cc1f003302acd57996dd7b31a53d04e7117e5dde5a494a3f8051R1-R40) [[2]](diffhunk://#diff-c8a50134c7b044c6fd53a53ff5c07b30c3389929c23c75be4b8258ac31301a7eR1) [[3]](diffhunk://#diff-139ee4c7d32bbac7fe4961e74d301c4a7969c5826266d1f587fda4b1adc3e3b4R1-R5)
- Introduced a unit test for the new component to verify its creation (`start-ride-button.component.spec.ts`).
- Defined `StartRideResponse` interface for API response typing (`api-responses.model.ts`).

**Integration with ride details page:**

- Updated `RideDetailsPageComponent` to import and render the new start ride button, and added a `refresh()` handler for the ride started event (`ride-details-page.component.ts`, `ride-details-page.component.html`). [[1]](diffhunk://#diff-96fbb632dc33861219080debc048975eeeac7c94642c0912a96afe9f1e8d7431R6-R17) [[2]](diffhunk://#diff-28da50419e23f34b37fe4b1e32204a3b468a6e83009ec1f127041b7bab3d6f95R4) [[3]](diffhunk://#diff-96fbb632dc33861219080debc048975eeeac7c94642c0912a96afe9f1e8d7431R36-R39)

**API service extension:**

- Extended `DriverRideService` to include a `startRide` method, using the new response type (`driver-ride.service.ts`). [[1]](diffhunk://#diff-987815b88532a7a761752c51a10986f704d5e37f03260f18dba833ff398e19d4R6) [[2]](diffhunk://#diff-987815b88532a7a761752c51a10986f704d5e37f03260f18dba833ff398e19d4R26-R32)