### PR TITLE
Add admin history

### DIFF
--- a/BACKEND/src/main/java/com/project/backend/controllers/RideController.java
+++ b/BACKEND/src/main/java/com/project/backend/controllers/RideController.java
@@ -2,6 +2,7 @@ package com.project.backend.controllers;
 
 import com.project.backend.DTO.Ride.*;
 import com.project.backend.exceptions.UnauthorizedException;
+import com.project.backend.models.Admin;
 import com.project.backend.models.AppUser;
 import com.project.backend.models.Customer;
 import com.project.backend.service.impl.CancellationService;
@@ -147,7 +148,8 @@ public class RideController {
             @RequestParam(name = "startDate", required = false)
                 @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime startDate,
             @RequestParam(name = "endDate", required = false)
-                @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime endDate
+                @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime endDate,
+            @RequestParam(name = "userID", required = false) Long userID
     ) {
         AppUser user = authUtils.getCurrentUser();
         if (user == null)
@@ -159,7 +161,10 @@ public class RideController {
             history = historyService.getDriverRideHistory(user.getId(), pageable, startDate, endDate);
         }
         if( user instanceof Customer ) {
-            history = historyService.getCustomerRideHistory((Customer) user, pageable, startDate, endDate);
+            history = historyService.getCustomerRideHistory(user.getId(), pageable, startDate, endDate);
+        }
+        if(user instanceof Admin) {
+            history = historyService.getRideHistoryForUserID(userID, pageable, startDate, endDate);
         }
 
         return ResponseEntity.status(HttpStatus.OK).body(history);

--- a/BACKEND/src/main/java/com/project/backend/service/IHistoryService.java
+++ b/BACKEND/src/main/java/com/project/backend/service/IHistoryService.java
@@ -10,5 +10,6 @@ import java.time.LocalDateTime;
 
 public interface IHistoryService {
     PagedResponse<RideResponseDTO> getDriverRideHistory(Long driverId, Pageable pageable, LocalDateTime startDate, LocalDateTime endDate);
-    PagedResponse<RideResponseDTO> getCustomerRideHistory(Customer customer, Pageable pageable, LocalDateTime startDate, LocalDateTime endDate);
+    PagedResponse<RideResponseDTO> getCustomerRideHistory(Long customerId, Pageable pageable, LocalDateTime startDate, LocalDateTime endDate);
+    PagedResponse<RideResponseDTO> getRideHistoryForUserID(Long userId, Pageable pageable, LocalDateTime startDate, LocalDateTime endDate);
 }


### PR DESCRIPTION
This pull request introduces enhancements to the ride history retrieval functionality, primarily allowing admins to fetch ride history for any user by user ID. It also refactors the `getCustomerRideHistory` method to use a customer ID instead of a `Customer` object, and adds a new method for general user-based ride history lookup. These changes improve flexibility and maintainability in the ride history services.