### PR TITLE
Fix DriverMatchingServiceImpl

### DIFF
--- a/BACKEND/src/main/java/com/project/backend/service/impl/DriverMatchingServiceImpl.java
+++ b/BACKEND/src/main/java/com/project/backend/service/impl/DriverMatchingServiceImpl.java
@@ -10,6 +10,7 @@ import com.project.backend.models.Driver;
 import com.project.backend.models.Ride;
 import com.project.backend.models.Vehicle;
 import com.project.backend.models.enums.DriverStatus;
+import com.project.backend.models.enums.RideStatus;
 import com.project.backend.repositories.DriverRepository;
 import com.project.backend.repositories.RideRepository;
 import com.project.backend.repositories.VehicleRepository;
@@ -158,9 +159,12 @@ public class DriverMatchingServiceImpl implements DriverMatchingService {
      * @param drivers map that holds driver's information, to which the ride information will be added
      */
     private void getRideData(Set<Long> driversIds, Map<Long, DriverInformation> drivers) {
-
+        var allowedStatuses = List.of(RideStatus.ACCEPTED, RideStatus.ACCEPTED, RideStatus.PANICKED);
         List<Ride> rides = rideRepository.findByDriverIdInAndEndTimeIsNullOrderByCreatedAtAsc(driversIds);
         for (var ride : rides) {
+            if (!allowedStatuses.contains(ride.getStatus())) {
+                continue;
+            }
             var driverInfo = drivers.get(ride.getDriver().getId());
             if (driverInfo == null) {
                 continue;
@@ -265,6 +269,11 @@ public class DriverMatchingServiceImpl implements DriverMatchingService {
         var dbDrivers = driverRepository.findAllByIdIn(driversIds.stream().toList());
         List<DriverStatus> allowedStatuses = List.of(DriverStatus.ACTIVE, DriverStatus.BUSY);
         for (var driver : dbDrivers) {
+            if (driver.getIsBlocked()) {
+                drivers.remove(driver.getId());
+                driversIds.remove(driver.getId());
+                continue;
+            }
             System.out.println("Checking driver " + driver.getId() + " with status " + driver.getDriverStatus());
             var driverInfo = drivers.get(driver.getId());
             driverInfo.setDriver(driver);


### PR DESCRIPTION
Closes #300 

This pull request enhances the driver matching logic by improving how driver and ride statuses are filtered. The changes ensure that only eligible drivers and rides are considered during the matching process, which should lead to more accurate and reliable driver assignments.

**Driver and Ride Status Filtering Improvements:**

* The `getRideData` method now filters rides to only include those with allowed statuses (`ACCEPTED`, `PANICKED`), preventing irrelevant rides from affecting driver selection.
* In `checkDriversActivity`, drivers who are blocked are now excluded from the pool of available drivers, ensuring that only active and eligible drivers are considered.

**Dependency Updates:**

* Added import for `RideStatus` enum to support the new ride status filtering logic.