### PR TITLE
Fix reports to include rides with different statuses

### DIFF
--- a/BACKEND/src/main/java/com/project/backend/repositories/reports/RideReportRepository.java
+++ b/BACKEND/src/main/java/com/project/backend/repositories/reports/RideReportRepository.java
@@ -1,6 +1,7 @@
 package com.project.backend.repositories.reports;
 
 import com.project.backend.models.Ride;
+import com.project.backend.models.enums.RideStatus;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -8,67 +9,68 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 public interface RideReportRepository {
-    // Get rides for a specific driver within date range
+
     @Query("SELECT r FROM Ride r " +
             "WHERE r.driver IS NOT NULL " +
             "AND r.driver.id = :driverId " +
-            "AND r.status = 'FINISHED' " +
+            "AND r.status IN :statuses " +
             "AND r.endTime >= :startDate " +
             "AND r.endTime < :endDate " +
             "ORDER BY r.endTime")
     List<Ride> findCompletedRidesByDriverAndDateRange(
             @Param("driverId") Long driverId,
             @Param("startDate") LocalDateTime startDate,
-            @Param("endDate") LocalDateTime endDate
+            @Param("endDate") LocalDateTime endDate,
+            @Param("statuses") List<RideStatus> statuses
     );
 
-    // Get rides for a specific passenger within date range
     @Query("SELECT r FROM Ride r " +
             "JOIN r.passengers p " +
             "WHERE p.user IS NOT NULL " +
             "AND p.user.id = :passengerId " +
-            "AND r.status = 'FINISHED' " +
+            "AND r.status IN :statuses " +
             "AND r.endTime >= :startDate " +
             "AND r.endTime < :endDate " +
             "ORDER BY r.endTime")
     List<Ride> findCompletedRidesByPassengerAndDateRange(
             @Param("passengerId") Long passengerId,
             @Param("startDate") LocalDateTime startDate,
-            @Param("endDate") LocalDateTime endDate
+            @Param("endDate") LocalDateTime endDate,
+            @Param("statuses") List<RideStatus> statuses
     );
 
-    // Get all completed rides for all drivers within date range
     @Query("SELECT r FROM Ride r " +
-            "WHERE r.status = 'FINISHED' " +
-            "AND r.driver IS NOT NULL " +
+            "WHERE r.driver IS NOT NULL " +
+            "AND r.status IN :statuses " +
             "AND r.endTime >= :startDate " +
             "AND r.endTime < :endDate " +
             "ORDER BY r.endTime")
     List<Ride> findAllCompletedRidesByDateRange(
             @Param("startDate") LocalDateTime startDate,
-            @Param("endDate") LocalDateTime endDate
+            @Param("endDate") LocalDateTime endDate,
+            @Param("statuses") List<RideStatus> statuses
     );
 
-    // Get all drivers who had rides in date range
     @Query("SELECT DISTINCT r.driver.id FROM Ride r " +
             "WHERE r.driver IS NOT NULL " +
-            "AND r.status = 'FINISHED' " +
+            "AND r.status IN :statuses " +
             "AND r.endTime >= :startDate " +
             "AND r.endTime < :endDate")
     List<Long> findDriverIdsWithRidesInDateRange(
             @Param("startDate") LocalDateTime startDate,
-            @Param("endDate") LocalDateTime endDate
+            @Param("endDate") LocalDateTime endDate,
+            @Param("statuses") List<RideStatus> statuses
     );
 
-    // Get all passengers who had rides in date range
     @Query("SELECT DISTINCT p.user.id FROM Ride r " +
             "JOIN r.passengers p " +
             "WHERE p.user IS NOT NULL " +
-            "AND r.status = 'FINISHED' " +
+            "AND r.status IN :statuses " +
             "AND r.endTime >= :startDate " +
             "AND r.endTime < :endDate")
     List<Long> findPassengerIdsWithRidesInDateRange(
             @Param("startDate") LocalDateTime startDate,
-            @Param("endDate") LocalDateTime endDate
+            @Param("endDate") LocalDateTime endDate,
+            @Param("statuses") List<RideStatus> statuses
     );
 }


### PR DESCRIPTION
Closes #303 

This pull request updates the reporting logic for rides to improve accuracy and flexibility. The main change is that reports now consider multiple ride statuses (not just "FINISHED") as billable, allowing for more comprehensive reporting on rides that were actually driven. The code has also been cleaned up for readability and consistency.

**Reporting logic improvements:**

* Introduced a `BILLABLE_STATUSES` list (`FINISHED`, `INTERRUPTED`, `PANICKED`) in `ReportService`, and updated all relevant queries and methods to use this list instead of filtering only by status `'FINISHED'`. This ensures that reports include all rides with meaningful data, not just those marked as finished. [[1]](diffhunk://#diff-ff6358300c6019eb46c5744c0576340b264f6a4f4a011e5f623603fd54d6f9e3R31-L35) [[2]](diffhunk://#diff-bd35ea26bb023e33f0c25054bfd2e50f1bf4b692b1b96f376f17b33667cf509fR4-R74) [[3]](diffhunk://#diff-ff6358300c6019eb46c5744c0576340b264f6a4f4a011e5f623603fd54d6f9e3L48-R65) [[4]](diffhunk://#diff-ff6358300c6019eb46c5744c0576340b264f6a4f4a011e5f623603fd54d6f9e3L107-L123) [[5]](diffhunk://#diff-ff6358300c6019eb46c5744c0576340b264f6a4f4a011e5f623603fd54d6f9e3L160-R170)
* Updated repository methods in `RideReportRepository` to accept a list of statuses as a parameter, and modified JPQL queries to use `IN :statuses` for status filtering.

**Report calculation and code cleanup:**

* Simplified and unified the calculation of total amounts in daily stats to always use `ride.getTotalCost()`, ensuring consistency between driver and passenger reports.
* Cleaned up code by removing redundant comments and unnecessary lines, and made some utility methods more concise. [[1]](diffhunk://#diff-ff6358300c6019eb46c5744c0576340b264f6a4f4a011e5f623603fd54d6f9e3L63-L67) [[2]](diffhunk://#diff-ff6358300c6019eb46c5744c0576340b264f6a4f4a011e5f623603fd54d6f9e3L84) [[3]](diffhunk://#diff-ff6358300c6019eb46c5744c0576340b264f6a4f4a011e5f623603fd54d6f9e3L96-L98) [[4]](diffhunk://#diff-ff6358300c6019eb46c5744c0576340b264f6a4f4a011e5f623603fd54d6f9e3L149-L151) [[5]](diffhunk://#diff-ff6358300c6019eb46c5744c0576340b264f6a4f4a011e5f623603fd54d6f9e3L197-L225) [[6]](diffhunk://#diff-ff6358300c6019eb46c5744c0576340b264f6a4f4a011e5f623603fd54d6f9e3L258-R272)

These changes make the reporting system more robust and maintainable, while ensuring that only rides with valid data are included in reports.